### PR TITLE
chore: Use Python 3.12 in .py script shebang header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ __pycache__/
 # assume "follow latest" for each use/installation.
 uv.lock
 requirements.txt
+
+# Ignore user's local Python virtual env
+.venv/

--- a/cdn_maintenance_toggle.py
+++ b/cdn_maintenance_toggle.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.11
+#!/usr/bin/env python3.12
 #
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
- Ignore user's .venv/ from source control